### PR TITLE
Change assert to allow empty messages to be forwarded downstream

### DIFF
--- a/src/mediahandlerelement.cpp
+++ b/src/mediahandlerelement.cpp
@@ -127,7 +127,7 @@ MediaHandlerElement::formIncomingControlMessage(message_ptr message,
 ChainedMessagesProduct
 MediaHandlerElement::formIncomingBinaryMessage(ChainedMessagesProduct messages,
                                                std::function<bool(ChainedOutgoingProduct)> send) {
-	assert(messages && !messages->empty());
+	assert(messages);
 	auto product = processIncomingBinaryMessage(messages);
 	prepareAndSendResponse(product.outgoing, send);
 	if (product.incoming) {


### PR DESCRIPTION
This will allow chain elements such as a defragmenter to buffer fragmented messages in order to forward the whole message once all the fragments are available.